### PR TITLE
Remove deprecated setting `canonifyURLs`

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,5 +1,4 @@
 baseURL = "https://mlange-42.github.io/knowledge/"
-canonifyurls = true
 languageCode = "en-us"
 title = "OESA Knowledge"
 


### PR DESCRIPTION
This PR allows to run the site without modifications, both locally and deployed to GitHub.